### PR TITLE
[FIX] socket disconnect 이벤트 핸들러 수정

### DIFF
--- a/src/modules/rooms/sockets/signaling.gateway.ts
+++ b/src/modules/rooms/sockets/signaling.gateway.ts
@@ -21,6 +21,9 @@ export class SignalingGateway {
     @SubscribeMessage('connection')
     handleConnection(@ConnectedSocket() client: Socket) {
         console.log('소켓 연결: ', client.id);
+        client.on('disconnect', (reason) => {
+            console.log(`${client.id} 연결 종료: ${reason}`);
+        });
     }
 
     @SubscribeMessage('join_room')
@@ -57,12 +60,11 @@ export class SignalingGateway {
         console.log('연결 종료 중... : ', client.id);
     }
 
-    @SubscribeMessage('disconnect')
-    handleDisconnection(
-        @ConnectedSocket() client: Socket,
-        @MessageBody() data: any,
-    ) {
-        let [reason] = data;
-        console.log(`${client.id} 연결 종료: ${reason}`);
-    }
+    // @SubscribeMessage('disconnect')
+    // handleDisconnection(
+    //     @ConnectedSocket() client: Socket,
+    //     @MessageBody() data: any,
+    // ) {
+    //     let [reason] = data;
+    // }
 }


### PR DESCRIPTION
별도로 subscribe 하던 disconnect 이벤트가 핸들링 되지 않는 현상 확인
connect 이벤트 핸들러 내부에서 client.on()으로 처리