### PR TITLE
add_member 이벤트 핸들러 수정 및 이벤트 리스너 등록 제한 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,10 @@ import { AuthModule } from './auth/auth.module';
 // import { UploadModule } from './uploads/uploads.module';
 import { UsersModule } from './modules/users/users.module';
 import { SocketsModule } from './modules/sockets/socket.module';
+import { RoomsModule } from './modules/rooms/rooms.module';
 
 @Module({
-    imports: [UsersModule, AuthModule, SocketsModule],
+    imports: [UsersModule, AuthModule, SocketsModule, RoomsModule],
     controllers: [AppController],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Config } from './config/configuration';
-import { join } from 'path';
 
 async function bootstrap() {
     const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -18,12 +17,13 @@ async function bootstrap() {
 
     process.on('warning', (e) => console.warn(e.stack));
 
-    const handleListen = () =>
+    const handleListen = () => {
         console.log(
             `Picpico-Server : Listening on http://${require('ip').address()}:${
                 Config.serverPort
             }`,
         );
+    };
     await app.listen(Config.serverPort, handleListen);
 }
 bootstrap();

--- a/src/modules/rooms/rooms.controller.ts
+++ b/src/modules/rooms/rooms.controller.ts
@@ -14,6 +14,8 @@ export class RoomsController {
         let socketId = roomInfo['socketId'];
         // Id가 roomId인 room을 메모리에 저장
         await this.roomService.createRoom(roomId, nickname, socketId);
+        console.log(await this.roomService.isRoom(roomId));
+
         console.log('POST: roomId: ', roomId);
         return { roomId: roomId };
     }

--- a/src/modules/rooms/rooms.service.ts
+++ b/src/modules/rooms/rooms.service.ts
@@ -23,8 +23,6 @@ export class RoomsService {
 
     // 방에서 나가기
     async leaveRoom(roomId: string, nickName: string) {
-        if (!(await this.isRoom(roomId))) return;
-
         const room = await this.redisService.getRoom(roomId);
         let removed = false;
 
@@ -45,19 +43,16 @@ export class RoomsService {
     }
 
     async getRoomHostName(roomId: string): Promise<string> {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         return room.host.nickName;
     }
 
     async getRoomHostId(roomId: string): Promise<string> {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         return room.host.socketId;
     }
 
     async setRoomHost(roomId: string, socketId: string): Promise<void> {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         room.host.socketId = socketId;
         await this.redisService.setRoom(roomId, room);
@@ -79,8 +74,6 @@ export class RoomsService {
         memberNickname: string,
         memberSocketId: string,
     ): Promise<void> {
-        if (!(await this.isRoom(roomId))) return;
-
         const room = await this.redisService.getRoom(roomId);
         room.members.push(new User(memberNickname, memberSocketId));
         await this.redisService.setRoom(roomId, room);
@@ -88,17 +81,13 @@ export class RoomsService {
 
     // 카메라: 방의 멤버들 리스트 꺼내기
     async getAllMembers(roomId: string): Promise<User[]> {
-        if (!(await this.isRoom(roomId))) return;
-
         const room = await this.redisService.getRoom(roomId);
         return room.members;
     }
 
     // 사진 찍기 준비
     async initPrevPicture(roomId: string, setId: string) {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
-
         room.prevPictures[setId] = new Array<PrevPicture>();
         await this.redisService.setRoom(roomId, room);
     }
@@ -109,7 +98,6 @@ export class RoomsService {
         picture: string,
         socketId: string,
     ) {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
 
         if (room.prevPictures[setId]) {
@@ -123,13 +111,11 @@ export class RoomsService {
     }
 
     async getPrevPicSize(roomId: string, setId: string): Promise<number> {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         return room.prevPictures[setId].length;
     }
 
     async removePrevPicture(roomId: string) {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         // 삭제 작업 아직 구현 안됨
         await this.redisService.setRoom(roomId, room);
@@ -139,15 +125,12 @@ export class RoomsService {
         roomId: string,
         setId: string,
     ): Promise<Array<PrevPicture>> {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         return room.prevPictures[setId];
     }
 
     // 카메라: 방에 찍은 사진 보관하기
     async takePicture(roomId: string, picNo: string, picture: string) {
-        if (!(await this.isRoom(roomId))) return;
-
         const pictureValue = new PictureValue(picture);
         const room = await this.redisService.getRoom(roomId);
 
@@ -168,15 +151,12 @@ export class RoomsService {
 
     // 카메라: 찍은 사진 목록 모두 꺼내오기
     async getAllPictures(roomId: string) {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
         return room.pictures;
     }
 
     // 사진선택: 찍은 사진의 선택 여부 변경하기
     async selectPicture(roomId: string, picNo: string) {
-        if (!(await this.isRoom(roomId))) return;
-
         const room = await this.redisService.getRoom(roomId);
         if (room.pictures[picNo]) {
             let selectFlag = room.pictures[picNo].selected;
@@ -205,7 +185,6 @@ export class RoomsService {
 
     // 꾸미기: 첫번째 사진에 viewer다 넣기
     async initPictureViewers(roomId: string) {
-        if (!(await this.isRoom(roomId))) return;
         const room = await this.redisService.getRoom(roomId);
 
         for (const [picNo, pic] of Object.entries(room.pictures)) {
@@ -226,8 +205,6 @@ export class RoomsService {
         nickname: string,
         imgIdx: string,
     ) {
-        if (!(await this.isRoom(roomId))) return;
-
         const room = await this.redisService.getRoom(roomId);
         room.pictures[imgIdx].viewers.push(new User(nickname, socketId));
 
@@ -240,8 +217,6 @@ export class RoomsService {
         socketId: string,
         imgIdx: string,
     ) {
-        if (!(await this.isRoom(roomId))) return;
-
         const room = await this.redisService.getRoom(roomId);
 
         if (!room.pictures[imgIdx]) return;

--- a/src/modules/sockets/gateways/camera.gateway.ts
+++ b/src/modules/sockets/gateways/camera.gateway.ts
@@ -26,8 +26,11 @@ export class CameraGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         const [roomId, newNickName] = data;
-        // if (!(await this.roomService.isRoom(roomId))) client.disconnect(true);
 
         client.nickName = newNickName;
         client.myRoomId = roomId;
@@ -47,6 +50,10 @@ export class CameraGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         const setIdx = data;
         console.log('[ click_shutter] on');
         console.log('[ click_shutter] setIdx', setIdx);
@@ -63,6 +70,10 @@ export class CameraGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ send_pic ] on');
         const [setIdx, picture] = data;
 
@@ -101,6 +112,10 @@ export class CameraGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ result_pic ] on');
 
         const [setIdx, picture] = data;
@@ -113,6 +128,10 @@ export class CameraGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ done_take ] on');
 
         const [roomId, socketId] = data;

--- a/src/modules/sockets/gateways/camera.gateway.ts
+++ b/src/modules/sockets/gateways/camera.gateway.ts
@@ -4,6 +4,7 @@ import {
     ConnectedSocket,
     MessageBody,
     WebSocketServer,
+    OnGatewayInit,
 } from '@nestjs/websockets';
 import { MyServer, MySocket } from '../socket.interface';
 import { Config } from '../../../config/configuration';
@@ -15,11 +16,15 @@ import { RoomsService } from '../../rooms/rooms.service';
         credentials: Config.socket.SOCKET_SIGNALING_CREDENTIALS,
     },
 })
-export class CameraGateway {
+export class CameraGateway implements OnGatewayInit {
     constructor(private readonly roomService: RoomsService) {}
 
     @WebSocketServer()
     server: MyServer;
+
+    afterInit(server: any) {
+        server.setMaxListeners(0);
+    }
 
     @SubscribeMessage('add_member')
     async handleAddMember(

--- a/src/modules/sockets/gateways/camera.gateway.ts
+++ b/src/modules/sockets/gateways/camera.gateway.ts
@@ -27,7 +27,7 @@ export class CameraGateway {
         @MessageBody() data: any,
     ) {
         const [roomId, newNickName] = data;
-        if (!(await this.roomService.isRoom(roomId))) client.disconnect(true);
+        // if (!(await this.roomService.isRoom(roomId))) client.disconnect(true);
 
         client.nickName = newNickName;
         client.myRoomId = roomId;

--- a/src/modules/sockets/gateways/deco.gateway.ts
+++ b/src/modules/sockets/gateways/deco.gateway.ts
@@ -58,13 +58,13 @@ export class DecoGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
-        if (!(await this.roomService.isRoom(client.myRoomId))) {
-            client.disconnect(true);
-        }
-
         console.log('[ done_deco ] on');
 
         const [roomId, clientId] = data;
+
+        if (!(await this.roomService.isRoom(roomId))) {
+            client.disconnect(true);
+        }
 
         // 호스트인지 여부 확인
         if (client.id === (await this.roomService.getRoomHostId(roomId))) {

--- a/src/modules/sockets/gateways/deco.gateway.ts
+++ b/src/modules/sockets/gateways/deco.gateway.ts
@@ -26,6 +26,10 @@ export class DecoGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ pick_deco ] on');
 
         const [socketId, toImgIdx, fromImgIdx] = data;
@@ -54,6 +58,10 @@ export class DecoGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ done_deco ] on');
 
         const [roomId, clientId] = data;
@@ -75,6 +83,10 @@ export class DecoGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ submit_deco ] on');
 
         if (

--- a/src/modules/sockets/gateways/drawing.gateway.ts
+++ b/src/modules/sockets/gateways/drawing.gateway.ts
@@ -17,7 +17,6 @@ import { Config } from '../../../config/configuration';
 })
 export class DrawingGateway {
     // constructor(private readonly roomService: RoomsService) {}
-
     @WebSocketServer()
     server: MyServer;
 
@@ -31,15 +30,22 @@ export class DrawingGateway {
             .to(client.myRoomId)
             .emit('mouse_down', fromSocket, offX, offY, ImgIdx);
     }
-
     @SubscribeMessage('stroke_canvas')
     async handleStrokeCanvas(
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
-        const [roomId, offX, offY, color, fromSocket, ImgIdx] = data;
+        const [roomId, offX, offY, color, fromSocket, ImgIdx, lineWidth] = data;
         client
             .to(roomId)
-            .emit('stroke_canvas', offX, offY, color, fromSocket, ImgIdx);
+            .emit(
+                'stroke_canvas',
+                offX,
+                offY,
+                color,
+                fromSocket,
+                ImgIdx,
+                lineWidth,
+            );
     }
 }

--- a/src/modules/sockets/gateways/drawing.gateway.ts
+++ b/src/modules/sockets/gateways/drawing.gateway.ts
@@ -30,6 +30,7 @@ export class DrawingGateway {
             .to(client.myRoomId)
             .emit('mouse_down', fromSocket, offX, offY, ImgIdx);
     }
+
     @SubscribeMessage('stroke_canvas')
     async handleStrokeCanvas(
         @ConnectedSocket() client: MySocket,
@@ -47,5 +48,16 @@ export class DrawingGateway {
                 ImgIdx,
                 lineWidth,
             );
+    }
+
+    @SubscribeMessage('mouse_up')
+    async handleMouseUp(
+        @ConnectedSocket() client: MySocket,
+        @MessageBody() data: any,
+    ) {
+        const [fromSocket, offX, offY, ImgIdx] = data;
+        client
+            .to(client.myRoomId)
+            .emit('stroke_canvas', fromSocket, offX, offY, ImgIdx);
     }
 }

--- a/src/modules/sockets/gateways/selection.gateway.ts
+++ b/src/modules/sockets/gateways/selection.gateway.ts
@@ -26,6 +26,10 @@ export class SelectionGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         const [roomId, picIdx] = data;
 
         console.log(`[ pick_pic ] on`);
@@ -49,6 +53,10 @@ export class SelectionGateway {
         @ConnectedSocket() client: MySocket,
         @MessageBody() data: any,
     ) {
+        if (!(await this.roomService.isRoom(client.myRoomId))) {
+            client.disconnect(true);
+        }
+
         console.log('[ done_pic ] on');
 
         const [roomId, socketId] = data;

--- a/src/modules/sockets/gateways/selection.gateway.ts
+++ b/src/modules/sockets/gateways/selection.gateway.ts
@@ -4,6 +4,7 @@ import {
     ConnectedSocket,
     MessageBody,
     WebSocketServer,
+    OnGatewayInit,
 } from '@nestjs/websockets';
 import { MyServer, MySocket } from '../socket.interface';
 import { Config } from '../../../config/configuration';
@@ -15,11 +16,15 @@ import { RoomsService } from '../../rooms/rooms.service';
         credentials: Config.socket.SOCKET_SIGNALING_CREDENTIALS,
     },
 })
-export class SelectionGateway {
+export class SelectionGateway implements OnGatewayInit {
     constructor(private readonly roomService: RoomsService) {}
 
     @WebSocketServer()
     server: MyServer;
+
+    afterInit(server: MyServer) {
+        server.setMaxListeners(100);
+    }
 
     @SubscribeMessage('pick_pic')
     async handlePickPic(

--- a/src/modules/sockets/gateways/signaling.gateway.ts
+++ b/src/modules/sockets/gateways/signaling.gateway.ts
@@ -19,20 +19,17 @@ import { RoomsService } from '../../rooms/rooms.service';
     },
 })
 export class SignalingGateway
-    implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit
+    implements OnGatewayConnection, OnGatewayDisconnect
 {
     constructor(private readonly roomService: RoomsService) {}
 
     @WebSocketServer()
     server: MyServer;
 
-    afterInit(server: MyServer) {
-        server.setMaxListeners(0);
-    }
-
     async handleConnection(@ConnectedSocket() client: MySocket) {
         client.myRoomId = Config.socket.DEFAULT_ROOM;
         console.log('[ 연결 성공 ] client.id = ', client.id);
+        client.setMaxListeners(100);
     }
 
     async handleDisconnect(@ConnectedSocket() client: MySocket) {

--- a/src/modules/sockets/gateways/signaling.gateway.ts
+++ b/src/modules/sockets/gateways/signaling.gateway.ts
@@ -6,6 +6,7 @@ import {
     WebSocketServer,
     OnGatewayConnection,
     OnGatewayDisconnect,
+    OnGatewayInit,
 } from '@nestjs/websockets';
 import { MyServer, MySocket } from '../socket.interface';
 import { Config } from '../../../config/configuration';
@@ -18,12 +19,16 @@ import { RoomsService } from '../../rooms/rooms.service';
     },
 })
 export class SignalingGateway
-    implements OnGatewayConnection, OnGatewayDisconnect
+    implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit
 {
     constructor(private readonly roomService: RoomsService) {}
 
     @WebSocketServer()
     server: MyServer;
+
+    afterInit(server: MyServer) {
+        server.setMaxListeners(0);
+    }
 
     async handleConnection(@ConnectedSocket() client: MySocket) {
         client.myRoomId = Config.socket.DEFAULT_ROOM;

--- a/src/modules/sockets/gateways/signaling.gateway.ts
+++ b/src/modules/sockets/gateways/signaling.gateway.ts
@@ -17,35 +17,37 @@ import { RoomsService } from '../../rooms/rooms.service';
         credentials: Config.socket.SOCKET_SIGNALING_CREDENTIALS,
     },
 })
-export class SignalingGateway {
+export class SignalingGateway
+    implements OnGatewayConnection, OnGatewayDisconnect
+{
     constructor(private readonly roomService: RoomsService) {}
 
     @WebSocketServer()
     server: MyServer;
 
-    // async handleConnection(@ConnectedSocket() client: MySocket) {
-    //     client.myRoomId = Config.socket.DEFAULT_ROOM;
-    //     console.log('[ 연결 성공 ] client.id = ', client.id);
-    // }
+    async handleConnection(@ConnectedSocket() client: MySocket) {
+        client.myRoomId = Config.socket.DEFAULT_ROOM;
+        console.log('[ 연결 성공 ] client.id = ', client.id);
+    }
 
-    // async handleDisconnect(@ConnectedSocket() client: MySocket) {
-    //     console.log('[ 연결 종료 ] client.id = ', client.id);
-    //     if (client.myRoomId !== Config.socket.DEFAULT_ROOM) {
-    //         client.to(client.myRoomId).emit('gone', client.id);
+    async handleDisconnect(@ConnectedSocket() client: MySocket) {
+        console.log('[ 연결 종료 ] client.id = ', client.id);
+        if (client.myRoomId !== Config.socket.DEFAULT_ROOM) {
+            client.to(client.myRoomId).emit('gone', client.id);
 
-    //         console.log(`[ 연결 종료 ] ${client.myRoomId} 에서`);
-    //         console.log(`[ 연결 종료 ] ${client.id} 이 나감.`);
+            console.log(`[ 연결 종료 ] ${client.myRoomId} 에서`);
+            console.log(`[ 연결 종료 ] ${client.id} 이 나감.`);
 
-    //         await this.roomService.leaveRoom(client.myRoomId, client.nickName);
-    //         const members = await this.roomService.getAllMembers(
-    //             client.myRoomId,
-    //         );
-    //         if (members.length === 0) {
-    //             await this.roomService.destroyRoom(client.myRoomId);
-    //         }
-    //         client.to(client.myRoomId).emit('reset_member', members);
-    //     }
-    // }
+            await this.roomService.leaveRoom(client.myRoomId, client.nickName);
+            const members = await this.roomService.getAllMembers(
+                client.myRoomId,
+            );
+            if (members.length === 0) {
+                await this.roomService.destroyRoom(client.myRoomId);
+            }
+            client.to(client.myRoomId).emit('reset_member', members);
+        }
+    }
 
     @SubscribeMessage('join_room')
     async handleJoinRoom(

--- a/src/modules/sockets/socket.decorators.ts
+++ b/src/modules/sockets/socket.decorators.ts
@@ -1,1 +1,9 @@
-function Room(roomId: string) {}
+function Room(value: string) {
+    return function (
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDecorator,
+    ) {
+        console.log(value);
+    };
+}

--- a/src/modules/sockets/socket.module.ts
+++ b/src/modules/sockets/socket.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
+import { RoomsModule } from '../rooms/rooms.module';
 import { SignalingGateway } from './gateways/signaling.gateway';
 import { CameraGateway } from './gateways/camera.gateway';
 import { DrawingGateway } from './gateways/drawing.gateway';
-import { RoomsModule } from '../rooms/rooms.module';
 import { SelectionGateway } from './gateways/selection.gateway';
 import { DecoGateway } from './gateways/deco.gateway';
 import { StickerGateway } from './gateways/sticker.gateway';


### PR DESCRIPTION
1. add_member 이벤트 핸들러 수정
    - roomId가 존재하는지 여부에 대한 체크를 
       client.myRoomId -> 인자로 전달된 roomId로 체크하는것으로 변경

2. 이벤트 리스너 등록 제한 수정
    - disconnect 이벤트가 @SubscribeMessage() 등록시 마다 add되는 현상 확인
    - 등록 가능한 이벤트 리스너의 수를 충분히 늘려놓는것으로 임시 조치함
    - 추후 @SubscribeMessage()의 동작 방식과 disconnect이벤트의 등록 방식에 대한 확인 필요